### PR TITLE
Initialize Flask backend scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,53 @@ If you're interested in contributing code, here's how to get started:
 
 3. **Install Dependencies** (to be determined as the project evolves):
    ```bash
-   pip install -r requirements.txt
+   pip install -e .
    ```
 
 4. **Start Developing**: Begin exploring the codebase, or help structure it as we define the initial architecture.
+
+## Backend Application
+
+LibraryAssembler now ships with a minimal Flask application that provides the
+foundation for future ingestion and automation features. The code lives under
+`src/libraryassembler/` and exposes a standard application factory (`create_app`).
+
+### Running the development server
+
+1. **Set the Flask application module**:
+   ```bash
+   export FLASK_APP=libraryassembler.app
+   ```
+
+2. **Initialise the database** (creates an SQLite database in the project root by default):
+   ```bash
+   flask --app libraryassembler.app init-db
+   ```
+
+3. **Start the server**:
+   ```bash
+   flask --app libraryassembler.app run --debug
+   ```
+
+Once running, you can verify the service with the bundled health-check
+endpoint:
+
+```bash
+curl http://127.0.0.1:5000/api/health
+```
+
+The default configuration stores data in `libraryassembler.db`, but you can
+override this by setting the `DATABASE_URL` environment variable before running
+the application.
+
+### Running tests
+
+The project includes a small test-suite to validate that the Flask factory and
+database bootstrap work correctly:
+
+```bash
+pytest
+```
 
 ## Project Structure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "libraryassembler"
+version = "0.1.0"
+description = "Core service for the LibraryAssembler digital library platform."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "Flask>=3.0",
+    "SQLAlchemy>=2.0",
+    "requests>=2.31",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/libraryassembler/__init__.py
+++ b/src/libraryassembler/__init__.py
@@ -1,0 +1,32 @@
+"""LibraryAssembler Flask application factory."""
+from __future__ import annotations
+
+import click
+from flask import Flask
+
+from .config import AppConfig
+from .database import init_app as init_database, init_db
+from .routes import register_blueprints
+
+
+def create_app(config: AppConfig | None = None) -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+
+    config = config or AppConfig.from_env()
+    config.apply(app)
+    app.config["APP_CONFIG"] = config
+
+    init_database(app)
+    register_blueprints(app)
+
+    @app.cli.command("init-db")
+    def init_db_command() -> None:
+        """Initialise the SQL database tables."""
+        init_db()
+        click.echo("Database initialised.")
+
+    return app
+
+
+__all__ = ["create_app", "AppConfig"]

--- a/src/libraryassembler/app.py
+++ b/src/libraryassembler/app.py
@@ -1,0 +1,8 @@
+"""WSGI entrypoint for running the application with ``flask --app``."""
+from __future__ import annotations
+
+from . import create_app
+
+app = create_app()
+
+__all__ = ["app"]

--- a/src/libraryassembler/config.py
+++ b/src/libraryassembler/config.py
@@ -1,0 +1,58 @@
+"""Application configuration utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from flask import Flask
+
+
+_DEF_DB_FILENAME = "libraryassembler.db"
+
+
+def _default_database_url() -> str:
+    """Build the default database URL for a local SQLite database."""
+    base_dir = Path(os.getenv("LIBRARYASSEMBLER_HOME", Path.cwd()))
+    db_path = base_dir / _DEF_DB_FILENAME
+    return f"sqlite:///{db_path}"
+
+
+def _bool_from_env(value: str | None, *, default: bool = False) -> bool:
+    """Parse a boolean environment variable."""
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+@dataclass(slots=True)
+class AppConfig:
+    """Configuration container with sane defaults for the application."""
+
+    app_name: str = "LibraryAssembler"
+    secret_key: str = field(default_factory=lambda: os.getenv("SECRET_KEY", "change-me"))
+    database_url: str = field(default_factory=lambda: os.getenv("DATABASE_URL", _default_database_url()))
+    sql_echo: bool = field(default_factory=lambda: _bool_from_env(os.getenv("SQLALCHEMY_ECHO")))
+    environment: str = field(default_factory=lambda: os.getenv("FLASK_ENV", os.getenv("ENVIRONMENT", "development")))
+    testing: bool = field(default_factory=lambda: _bool_from_env(os.getenv("TESTING")))
+
+    @classmethod
+    def from_env(cls) -> "AppConfig":
+        """Build a configuration object using environment variables."""
+        return cls()
+
+    def apply(self, app: "Flask") -> None:
+        """Apply the configuration to a Flask application instance."""
+        app.config.update(
+            APP_NAME=self.app_name,
+            SECRET_KEY=self.secret_key,
+            SQLALCHEMY_DATABASE_URI=self.database_url,
+            SQLALCHEMY_ECHO=self.sql_echo,
+            ENV=self.environment,
+            TESTING=self.testing,
+        )
+
+
+__all__ = ["AppConfig"]

--- a/src/libraryassembler/config.py
+++ b/src/libraryassembler/config.py
@@ -30,8 +30,10 @@ def _default_secret_key() -> str:
 
 def _default_database_url() -> str:
     """Build the default database URL for a local SQLite database."""
-    base_dir = Path(os.getenv("LIBRARYASSEMBLER_HOME", Path.cwd()))
-    db_path = base_dir / _DEF_DB_FILENAME
+    package_dir = Path(__file__).resolve().parent
+    raw_home = os.getenv("LIBRARYASSEMBLER_HOME")
+    base_dir = Path(raw_home).expanduser() if raw_home else package_dir
+    db_path = (base_dir / _DEF_DB_FILENAME).resolve()
     return f"sqlite:///{db_path}"
 
 

--- a/src/libraryassembler/config.py
+++ b/src/libraryassembler/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import os
 from pathlib import Path
+import secrets
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -11,6 +12,20 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 _DEF_DB_FILENAME = "libraryassembler.db"
+
+
+def _default_secret_key() -> str:
+    """Return a secure default secret key.
+
+    The SECRET_KEY environment variable is respected when provided; otherwise a
+    new random value is generated so development instances do not share a
+    predictable secret.
+    """
+
+    env_value = os.getenv("SECRET_KEY")
+    if env_value:
+        return env_value
+    return secrets.token_urlsafe(32)
 
 
 def _default_database_url() -> str:
@@ -32,7 +47,7 @@ class AppConfig:
     """Configuration container with sane defaults for the application."""
 
     app_name: str = "LibraryAssembler"
-    secret_key: str = field(default_factory=lambda: os.getenv("SECRET_KEY", "change-me"))
+    secret_key: str = field(default_factory=_default_secret_key)
     database_url: str = field(default_factory=lambda: os.getenv("DATABASE_URL", _default_database_url()))
     sql_echo: bool = field(default_factory=lambda: _bool_from_env(os.getenv("SQLALCHEMY_ECHO")))
     environment: str = field(default_factory=lambda: os.getenv("FLASK_ENV", os.getenv("ENVIRONMENT", "development")))

--- a/src/libraryassembler/database.py
+++ b/src/libraryassembler/database.py
@@ -1,0 +1,114 @@
+"""Database utilities built around SQLAlchemy."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from flask import Flask, g
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+
+class Base(DeclarativeBase):
+    """Base class for SQLAlchemy models."""
+
+
+_engine: Engine | None = None
+_session_factory: sessionmaker[Session] | None = None
+
+
+def init_engine(database_url: str, *, echo: bool = False) -> Engine:
+    """Initialise the global SQLAlchemy engine."""
+    global _engine
+    _engine = create_engine(database_url, echo=echo, future=True)
+    return _engine
+
+
+def get_engine() -> Engine:
+    """Return the configured SQLAlchemy engine."""
+    if _engine is None:
+        raise RuntimeError("The SQLAlchemy engine has not been initialised.")
+    return _engine
+
+
+def init_session_factory(engine: Engine | None = None) -> sessionmaker[Session]:
+    """Create a session factory tied to the provided engine."""
+    global _session_factory
+    engine = engine or get_engine()
+    _session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    return _session_factory
+
+
+def get_session_factory() -> sessionmaker[Session]:
+    """Return the configured session factory."""
+    if _session_factory is None:
+        raise RuntimeError("The SQLAlchemy session factory has not been initialised.")
+    return _session_factory
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+    factory = get_session_factory()
+    session = factory()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def init_app(app: Flask) -> None:
+    """Configure the Flask app with database helpers."""
+    engine = init_engine(app.config["SQLALCHEMY_DATABASE_URI"], echo=app.config.get("SQLALCHEMY_ECHO", False))
+    factory = init_session_factory(engine)
+
+    @app.teardown_appcontext
+    def cleanup_session(exception: BaseException | None = None) -> None:
+        session: Session | None = g.pop("db_session", None)
+        if session is None:
+            return
+        if exception is not None:
+            session.rollback()
+        else:
+            try:
+                session.commit()
+            except Exception:  # pragma: no cover - defensive cleanup
+                session.rollback()
+                raise
+        session.close()
+
+    app.extensions["sqlalchemy_engine"] = engine
+    app.extensions["sqlalchemy_session_factory"] = factory
+
+
+def get_session() -> Session:
+    """Return a request-scoped session, creating one if necessary."""
+    if "db_session" not in g:
+        factory = get_session_factory()
+        g.db_session = factory()
+    return g.db_session
+
+
+def init_db() -> None:
+    """Create all database tables registered on the declarative base."""
+    # Import models so they are registered with the metadata before creation.
+    from . import models  # noqa: F401  # pylint: disable=unused-import
+
+    engine = get_engine()
+    Base.metadata.create_all(bind=engine)
+
+
+__all__ = [
+    "Base",
+    "get_engine",
+    "get_session",
+    "init_app",
+    "init_db",
+    "init_engine",
+    "init_session_factory",
+    "session_scope",
+]

--- a/src/libraryassembler/models/__init__.py
+++ b/src/libraryassembler/models/__init__.py
@@ -1,0 +1,7 @@
+"""SQLAlchemy models for LibraryAssembler."""
+from __future__ import annotations
+
+from .ingestion import IngestionJob, IngestionStatus
+from .media_item import MediaItem
+
+__all__ = ["IngestionJob", "IngestionStatus", "MediaItem"]

--- a/src/libraryassembler/models/ingestion.py
+++ b/src/libraryassembler/models/ingestion.py
@@ -1,0 +1,54 @@
+"""Ingestion-related models."""
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import DateTime, Enum as SQLEnum, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..database import Base
+
+
+class IngestionStatus(str, Enum):
+    """Lifecycle states for an ingestion job."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class IngestionJob(Base):
+    """Tracks the ingestion of library items from external sources."""
+
+    __tablename__ = "ingestion_jobs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    source: Mapped[str] = mapped_column(String(128), nullable=False)
+    status: Mapped[IngestionStatus] = mapped_column(
+        SQLEnum(IngestionStatus, name="ingestion_status"), nullable=False, default=IngestionStatus.PENDING
+    )
+    payload: Mapped[Optional[str]] = mapped_column(Text())
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+    error_message: Mapped[Optional[str]] = mapped_column(Text())
+
+    def mark_failed(self, message: str) -> None:
+        """Mark the job as failed with an explanatory message."""
+        self.status = IngestionStatus.FAILED
+        self.error_message = message
+
+    def mark_completed(self) -> None:
+        """Mark the job as completed."""
+        self.status = IngestionStatus.COMPLETED
+        self.error_message = None
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return f"<IngestionJob id={self.id!r} status={self.status!r}>"
+
+
+__all__ = ["IngestionJob", "IngestionStatus"]

--- a/src/libraryassembler/models/media_item.py
+++ b/src/libraryassembler/models/media_item.py
@@ -1,0 +1,32 @@
+"""Media item model definition."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..database import Base
+
+
+class MediaItem(Base):
+    """Represents an item in the managed digital library."""
+
+    __tablename__ = "media_items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    author: Mapped[Optional[str]] = mapped_column(String(255))
+    media_type: Mapped[Optional[str]] = mapped_column(String(64))
+    source: Mapped[Optional[str]] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return f"<MediaItem id={self.id!r} title={self.title!r}>"
+
+
+__all__ = ["MediaItem"]

--- a/src/libraryassembler/routes/__init__.py
+++ b/src/libraryassembler/routes/__init__.py
@@ -1,0 +1,14 @@
+"""Route registration helpers."""
+from __future__ import annotations
+
+from flask import Flask
+
+from .health import bp as health_bp
+
+
+def register_blueprints(app: Flask) -> None:
+    """Attach all application blueprints to the Flask instance."""
+    app.register_blueprint(health_bp)
+
+
+__all__ = ["register_blueprints"]

--- a/src/libraryassembler/routes/__init__.py
+++ b/src/libraryassembler/routes/__init__.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 from flask import Flask
 
 from .health import bp as health_bp
+from .home import bp as home_bp
 
 
 def register_blueprints(app: Flask) -> None:
     """Attach all application blueprints to the Flask instance."""
+    app.register_blueprint(home_bp)
     app.register_blueprint(health_bp)
 
 

--- a/src/libraryassembler/routes/health.py
+++ b/src/libraryassembler/routes/health.py
@@ -14,8 +14,13 @@ bp = Blueprint("health", __name__, url_prefix="/api")
 def healthcheck():
     """Return basic application and database health information."""
     session = get_session()
-    media_count = session.scalar(select(func.count(MediaItem.id))) or 0
-    ingestion_count = session.scalar(select(func.count(IngestionJob.id))) or 0
+    counts_stmt = select(
+        select(func.count(MediaItem.id)).scalar_subquery(),
+        select(func.count(IngestionJob.id)).scalar_subquery(),
+    )
+    media_count, ingestion_count = session.execute(counts_stmt).one()
+    media_count = int(media_count or 0)
+    ingestion_count = int(ingestion_count or 0)
     return (
         jsonify(
             {

--- a/src/libraryassembler/routes/health.py
+++ b/src/libraryassembler/routes/health.py
@@ -1,0 +1,31 @@
+"""Health check endpoints."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify
+from sqlalchemy import func, select
+
+from ..database import get_session
+from ..models import IngestionJob, MediaItem
+
+bp = Blueprint("health", __name__, url_prefix="/api")
+
+
+@bp.get("/health")
+def healthcheck():
+    """Return basic application and database health information."""
+    session = get_session()
+    media_count = session.scalar(select(func.count(MediaItem.id))) or 0
+    ingestion_count = session.scalar(select(func.count(IngestionJob.id))) or 0
+    return (
+        jsonify(
+            {
+                "status": "ok",
+                "media_items": media_count,
+                "ingestion_jobs": ingestion_count,
+            }
+        ),
+        200,
+    )
+
+
+__all__ = ["bp"]

--- a/src/libraryassembler/routes/health.py
+++ b/src/libraryassembler/routes/health.py
@@ -14,19 +14,14 @@ bp = Blueprint("health", __name__, url_prefix="/api")
 def healthcheck():
     """Return basic application and database health information."""
     session = get_session()
-    counts_stmt = select(
-        select(func.count(MediaItem.id)).scalar_subquery(),
-        select(func.count(IngestionJob.id)).scalar_subquery(),
-    )
-    media_count, ingestion_count = session.execute(counts_stmt).one()
-    media_count = int(media_count or 0)
-    ingestion_count = int(ingestion_count or 0)
+    media_count = session.scalar(select(func.count()).select_from(MediaItem)) or 0
+    ingestion_count = session.scalar(select(func.count()).select_from(IngestionJob)) or 0
     return (
         jsonify(
             {
                 "status": "ok",
-                "media_items": media_count,
-                "ingestion_jobs": ingestion_count,
+                "media_items": int(media_count),
+                "ingestion_jobs": int(ingestion_count),
             }
         ),
         200,

--- a/src/libraryassembler/routes/home.py
+++ b/src/libraryassembler/routes/home.py
@@ -1,0 +1,17 @@
+"""Homepage routes for LibraryAssembler."""
+from __future__ import annotations
+
+from flask import Blueprint, current_app, jsonify
+
+bp = Blueprint("home", __name__)
+
+
+@bp.get("/")
+def index():
+    """Return a friendly JSON message for the homepage."""
+    app_config = current_app.config.get("APP_CONFIG")
+    app_name = getattr(app_config, "app_name", current_app.config.get("APP_NAME", "LibraryAssembler"))
+    return jsonify({
+        "app": app_name,
+        "message": "Welcome to the LibraryAssembler service.",
+    })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the ``src`` directory is importable when the package is not installed.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from libraryassembler import AppConfig, create_app
+from libraryassembler.database import init_db
+
+
+def build_test_config(tmp_path: Path) -> AppConfig:
+    db_path = tmp_path / "test.db"
+    return AppConfig(
+        database_url=f"sqlite:///{db_path}",
+        testing=True,
+        sql_echo=False,
+        secret_key="test-secret",
+    )
+
+
+def test_healthcheck_endpoint(tmp_path):
+    app = create_app(build_test_config(tmp_path))
+    with app.app_context():
+        init_db()
+
+    client = app.test_client()
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "ok"
+    assert payload["media_items"] == 0
+    assert payload["ingestion_jobs"] == 0
+
+
+def test_init_db_cli(tmp_path):
+    app = create_app(build_test_config(tmp_path))
+    runner = app.test_cli_runner()
+    result = runner.invoke(args=["init-db"])
+    assert result.exit_code == 0
+    assert "Database initialised." in result.output

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,6 +30,17 @@ def test_healthcheck_endpoint(tmp_path):
     assert payload["ingestion_jobs"] == 0
 
 
+def test_homepage_returns_welcome_message(tmp_path):
+    app = create_app(build_test_config(tmp_path))
+    client = app.test_client()
+
+    response = client.get("/")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["app"] == "LibraryAssembler"
+    assert "welcome" in payload["message"].lower()
+
+
 def test_init_db_cli(tmp_path):
     app = create_app(build_test_config(tmp_path))
     runner = app.test_cli_runner()


### PR DESCRIPTION
## Summary
- set up a pyproject-based Python package that exposes the LibraryAssembler Flask application
- add configuration, database helpers, models, and a health check endpoint wired to SQLAlchemy
- document the new backend workflow and cover the app factory with pytest-based smoke tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c857f8da7c83338722c47b781b99df